### PR TITLE
docs: Añadir URL de la aplicación desplegada al README

### DIFF
--- a/BITACORA.md
+++ b/BITACORA.md
@@ -1,0 +1,106 @@
+# Bitácora de Tiempo Invertido (Según Historial de Commits Completo)
+
+Esta bitácora se basa en el análisis del historial de `git log` completo del repositorio, proporcionado por el usuario. El historial consta de 10 commits que detallan la evolución del proyecto `reditop`.
+
+## Resumen del Proceso de Desarrollo
+
+El desarrollo del proyecto `reditop` se extendió a lo largo de aproximadamente tres días, desde la madrugada del domingo 29 de junio de 2025 hasta la madrugada del martes 1 de julio de 2025. El proceso muestra una construcción incremental de la aplicación, comenzando con la inicialización del proyecto, seguido por la integración de herramientas y estilos, la implementación de la lógica central de Reddit, la creación de componentes UI y finalmente, la adición de características y mejoras.
+
+## Detalle de Commits
+
+A continuación, se presenta el detalle de los commits en orden cronológico inverso (el más reciente primero):
+
+1.  **Commit:** `d3fdefeedda50c31da26417679593ff222301585` (Merge)
+    *   **Autor:** `davidvargas`
+    *   **Fecha:** `Tue Jul 1 02:14:39 2025 -0500`
+    *   **Mensaje:** `Merge remote-tracking branch 'origin/main'`
+    *   **Descripción:** Commit de merge, integrando cambios de la rama remota `origin/main`. Esto usualmente ocurre después de que cambios han sido pusheados al repositorio remoto desde otro lugar o por otros colaboradores (o para sincronizar el historial local con el remoto).
+    *   **Tiempo desde el commit anterior:** Inmediatamente después del commit `ad202e3`.
+
+2.  **Commit:** `ad202e3ef2e6134986281774736fc6d890d9a13d`
+    *   **Autor:** `davidvargas`
+    *   **Fecha:** `Tue Jul 1 02:14:27 2025 -0500`
+    *   **Mensaje:** `Update build targets and configurations for modern browsers, improve type safety in components, remove deprecated withDefaults, and refactor script setup with TypeScript.`
+    *   **Funcionalidades/Mejoras:**
+        *   Actualización de la configuración de compilación (build targets) para navegadores modernos.
+        *   Mejoras en la seguridad de tipos (type safety) en los componentes Vue.
+        *   Eliminación de `withDefaults` (probablemente de Vue, obsoleto en ciertas versiones o setups).
+        *   Refactorización del `script setup` en componentes Vue con TypeScript.
+    *   **Tiempo desde el commit anterior:** Aproximadamente 23 minutos.
+
+3.  **Commit:** `470d64478e9618b4ca9ab1ae61c17f7edac7b785`
+    *   **Autor:** `David Vargas` (Nótese la ligera diferencia en el nombre del autor)
+    *   **Fecha:** `Tue Jul 1 01:51:07 2025 -0500`
+    *   **Mensaje:** `Create CNAME`
+    *   **Descripción:** Creación de un archivo CNAME, usualmente utilizado para configurar un dominio personalizado en servicios de hosting como GitHub Pages.
+    *   **Tiempo desde el commit anterior:** Aproximadamente 6 minutos.
+
+4.  **Commit:** `fc3c3157830f1d5eacb4ce0e2a842c1bba7ca6e2`
+    *   **Autor:** `davidvargas`
+    *   **Fecha:** `Tue Jul 1 01:45:00 2025 -0500`
+    *   **Mensaje:** `Add image downloading functionality, improve Reddit store with local storage synchronization, update UI components for detailed post view, and enhance Tailwind configuration.`
+    *   **Funcionalidades/Mejoras:** Descarga de imágenes, sincronización del store con `localStorage`, actualizaciones UI para vista detallada, mejoras en Tailwind.
+    *   **Tiempo desde el commit anterior:** Aproximadamente 3 horas y 30 minutos.
+
+5.  **Commit:** `a39e650459025fc6def43b830390fb005b127d9f`
+    *   **Autor:** `davidvargas`
+    *   **Fecha:** `Mon Jun 30 22:14:29 2025 -0500`
+    *   **Mensaje:** `Refactor dialog components: centralize logic in useDialog, improve accessibility, and enhance animations. Add UImageDialog for image previews. Update dependencies and utility functions.`
+    *   **Funcionalidades/Mejoras:** Refactorización de diálogos, `useDialog`, `UImageDialog`, actualización de dependencias y utilidades.
+    *   **Tiempo desde el commit anterior:** Aproximadamente 3 horas y 18 minutos.
+
+6.  **Commit:** `0be97003ae09cd30204eaa1bc0205d702ddde950`
+    *   **Autor:** `davidvargas`
+    *   **Fecha:** `Mon Jun 30 18:55:55 2025 -0500`
+    *   **Mensaje:** `Add pagination to Reddit store and implement UPagination component`
+    *   **Funcionalidades/Mejoras:** Paginación en el store de Reddit e implementación del componente `UPagination`.
+    *   **Tiempo desde el commit anterior:** Aproximadamente 47 minutos.
+
+7.  **Commit:** `e245b272ea5b62c7e83e3cee811d5484f1b6596d`
+    *   **Autor:** `davidvargas`
+    *   **Fecha:** `Mon Jun 30 18:08:45 2025 -0500`
+    *   **Mensaje:** `Implement dialog components, improve Reddit store logic, enhance UI interactions, and add utility functions.`
+    *   **Funcionalidades/Mejoras:** Implementación de componentes de diálogo, mejoras en la lógica del store de Reddit, interacciones UI y funciones de utilidad.
+    *   **Tiempo desde el commit anterior:** Aproximadamente 15 horas y 3 minutos (esto sugiere una pausa larga en el trabajo o trabajo realizado que no se confirmó hasta mucho después).
+
+8.  **Commit:** `7ec1946aed7d3be4a6c687c5b4a8b37729919765`
+    *   **Autor:** `davidvargas`
+    *   **Fecha:** `Mon Jun 30 03:05:42 2025 -0500`
+    *   **Mensaje:** `Replace example components and setup Reddit store with API integration. Add notification support.`
+    *   **Funcionalidades/Mejoras:** Reemplazo de componentes de ejemplo, configuración del store de Reddit con integración API, soporte para notificaciones.
+    *   **Tiempo desde el commit anterior:** Aproximadamente 25 horas y 22 minutos (similar al anterior, sugiere una pausa larga o trabajo no confirmado).
+
+9.  **Commit:** `181888190d516f0781dcf5d8b4f7e790d12bf5ad`
+    *   **Autor:** `davidvargas`
+    *   **Fecha:** `Sun Jun 29 01:43:26 2025 -0500`
+    *   **Mensaje:** `Integrate Tailwind CSS, update base styles, remove example views, and add new dependencies.`
+    *   **Funcionalidades/Mejoras:** Integración de Tailwind CSS, actualización de estilos base, eliminación de vistas de ejemplo, adición de dependencias.
+    *   **Tiempo desde el commit anterior:** Aproximadamente 40 minutos.
+
+10. **Commit:** `094401609ec57677b88bdad61e3e504a2b21da1c`
+    *   **Autor:** `davidvargas`
+    *   **Fecha:** `Sun Jun 29 01:03:18 2025 -0500`
+    *   **Mensaje:** `Initialize Vue 2 project with TypeScript, Pinia, Vue Router, Cypress, and Vitest`
+    *   **Funcionalidades/Mejoras:** Inicialización del proyecto Vue 2 con las tecnologías base.
+
+## Estimación del Tiempo Total Invertido
+
+*   **Inicio del proyecto (primer commit):** Domingo 29 de junio de 2025, 01:03:18
+*   **Último commit de desarrollo (antes del merge):** Martes 1 de julio de 2025, 02:14:27
+
+El tiempo total transcurrido desde el primer commit hasta el último commit de desarrollo es de aproximadamente **2 días, 1 hora y 11 minutos**.
+
+Sin embargo, es importante notar las largas pausas entre algunos commits (especialmente entre `7ec1946...` y `e245b27...`, y entre `1818881...` y `7ec1946...`). Si sumamos solo los periodos de actividad más concentrada, el tiempo de desarrollo activo podría ser menor.
+
+**Desglose por días (aproximado):**
+
+*   **Sábado/Domingo (madrugada del 29 de junio):** Trabajo inicial de configuración e integración de Tailwind (aproximadamente 40 minutos según los commits).
+*   **Domingo/Lunes (madrugada del 30 de junio):** Configuración del store, API y notificaciones (commit `7ec1946...`).
+*   **Lunes (tarde/noche del 30 de junio):** Implementación de diálogos, paginación, refactorización de diálogos, adición de `UImageDialog` (commits `e245b27...`, `0be9700...`, `a39e650...`). Esta fue una sesión de trabajo intensiva de aproximadamente 4 horas y 6 minutos.
+*   **Lunes/Martes (madrugada del 1 de julio):** Funcionalidad de descarga, persistencia de datos, UI, configuración de CNAME, y configuraciones finales de build (commits `fc3c315...`, `470d644...`, `ad202e3...`). Esta sesión fue de aproximadamente 29 minutos hasta el último commit de desarrollo (sin contar el merge).
+
+Considerando estos bloques, el tiempo de desarrollo activo parece estar concentrado en ráfagas, con un esfuerzo total que podría estimarse entre **6 y 8 horas de trabajo focalizado**, distribuidas a lo largo de los tres días. La solicitud original sugería no pasar más de 2 días en total, y el grueso del desarrollo parece haberse concentrado en el lunes 30 de junio y la madrugada del 1 de julio.
+
+---
+
+*Esta bitácora fue elaborada por Jules, el asistente de IA, basándose en la información de `git log` completa proporcionada por el usuario.*

--- a/README.md
+++ b/README.md
@@ -1,59 +1,116 @@
-# reditop
+# Reditop: Visualizador de Posts Populares de Reddit
 
-This template should help get you started developing with Vue 3 in Vite.
+Reditop es una aplicación web diseñada para explorar los posts más populares del subreddit `r/all` de Reddit. Permite a los usuarios visualizar, interactuar y gestionar una lista de posts de forma sencilla e intuitiva.
 
-## Recommended IDE Setup
+**🚀 Puedes visitar la aplicación desplegada en: [https://reditop.online/](https://reditop.online/)**
 
-[VSCode](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and disable Vetur) + [TypeScript Vue Plugin (Volar)](https://marketplace.visualstudio.com/items?itemName=Vue.vscode-typescript-vue-plugin).
+## Características Principales
 
-## Type Support for `.vue` Imports in TS
+*   **Visualización Clara:** Muestra una lista de posts con información relevante como título, autor, puntuación, número de comentarios e imagen en miniatura.
+*   **Detalle Interactivo:** Al seleccionar un post, se accede a una vista detallada que incluye la imagen en alta resolución (si está disponible) y el contenido completo del post. Los usuarios pueden hacer clic en las imágenes en miniatura para verlas en un diálogo ampliado y descargarlas.
+*   **Gestión de Posts:**
+    *   Los posts se marcan automáticamente como leídos al ser seleccionados.
+    *   Opción para descartar posts individualmente o todos a la vez, eliminándolos de la vista actual.
+    *   Funcionalidad para actualizar la lista y cargar los posts más recientes.
+    *   Posibilidad de reiniciar la aplicación a su estado inicial, limpiando todos los datos almacenados.
+*   **Paginación Eficiente:** La lista de posts está paginada para una navegación fluida y un rendimiento óptimo.
+*   **Estado Persistente:** Reditop utiliza `localStorage` para guardar el estado de los posts (cargados, leídos, descartados) y el post seleccionado, asegurando que la experiencia del usuario se mantenga entre sesiones.
+*   **Diseño Responsivo:** La interfaz se adapta a diferentes tamaños de pantalla, ofreciendo una experiencia de usuario consistente en dispositivos de escritorio y móviles. En móviles, la lista de posts se presenta en una barra lateral desplegable.
+*   **Notificaciones en Tiempo Real:** Informa al usuario sobre acciones importantes como la actualización de posts, el descarte de publicaciones, etc.
+*   **Manejo de Errores:** Proporciona retroalimentación al usuario en caso de problemas al cargar los posts desde la API de Reddit, con opción de reintentar la carga.
 
-TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking. In editors, we need [TypeScript Vue Plugin (Volar)](https://marketplace.visualstudio.com/items?itemName=Vue.vscode-typescript-vue-plugin) to make the TypeScript language service aware of `.vue` types.
+## Tecnologías Utilizadas
 
-If the standalone TypeScript plugin doesn't feel fast enough to you, Volar has also implemented a [Take Over Mode](https://github.com/johnsoncodehk/volar/discussions/471#discussioncomment-1361669) that is more performant. You can enable it by the following steps:
-
-1. Disable the built-in TypeScript Extension
-    1) Run `Extensions: Show Built-in Extensions` from VSCode's command palette
-    2) Find `TypeScript and JavaScript Language Features`, right click and select `Disable (Workspace)`
-2. Reload the VSCode window by running `Developer: Reload Window` from the command palette.
-
-## Customize configuration
-
-See [Vite Configuration Reference](https://vitejs.dev/config/).
+*   **Vue.js 2:** Framework progresivo para la construcción de la interfaz de usuario.
+*   **Vite:** Herramienta moderna de frontend para un desarrollo rápido y empaquetado eficiente.
+*   **Pinia:** Librería para la gestión del estado de la aplicación.
+*   **Vue Router:** Para la gestión de rutas en la aplicación (configuración base presente).
+*   **TypeScript:** Superset de JavaScript que añade tipado estático para un desarrollo más robusto.
+*   **Tailwind CSS:** Framework CSS de utilidad para un diseño rápido y personalizable.
+*   **Axios:** Cliente HTTP basado en promesas para realizar peticiones a la API de Reddit.
+*   **Lucide Vue:** Librería de iconos SVG ligeros y personalizables.
+*   **PortalVue:** Para renderizar componentes (como notificaciones) fuera de la jerarquía DOM principal.
+*   **VueUse:** Colección de funciones composables esenciales para Vue.js.
 
 ## Project Setup
 
-```sh
-npm install
-```
+Asegúrate de tener [Node.js](https://nodejs.org/) instalado (se recomienda la versión LTS).
+
+1.  Clona el repositorio:
+    ```sh
+    git clone https://repository-url.git # Reemplazar con la URL real del repositorio
+    cd reditop
+    ```
+
+2.  Instala las dependencias del proyecto:
+    ```sh
+    npm install
+    # o
+    yarn install
+    ```
 
 ### Compile and Hot-Reload for Development
 
+Para iniciar el servidor de desarrollo con recarga en caliente:
+
 ```sh
 npm run dev
+# o
+yarn dev
 ```
+
+La aplicación estará disponible en `http://localhost:5173` (o el puerto que indique Vite).
 
 ### Type-Check, Compile and Minify for Production
 
+Para compilar y minificar la aplicación para producción:
+
 ```sh
 npm run build
+# o
+yarn build
 ```
+
+Esto generará los archivos estáticos en el directorio `dist/`.
 
 ### Run Unit Tests with [Vitest](https://vitest.dev/)
 
+Para ejecutar las pruebas unitarias:
+
 ```sh
 npm run test:unit
+# o
+yarn test:unit
 ```
 
 ### Run End-to-End Tests with [Cypress](https://www.cypress.io/)
 
-```sh
-npm run build
-npm run test:e2e # or `npm run test:e2e:ci` for headless testing
-```
+Para ejecutar las pruebas end-to-end:
+
+1.  Asegúrate de que la aplicación esté construida (`npm run build` o `yarn build`).
+2.  Ejecuta los tests:
+    ```sh
+    npm run test:e2e
+    # o
+    yarn test:e2e
+    ```
+    Esto abrirá la interfaz de Cypress. Para ejecutar en modo headless (CI):
+    ```sh
+    npm run test:e2e:ci
+    # o
+    yarn test:e2e:ci
+    ```
 
 ### Lint with [ESLint](https://eslint.org/)
 
+Para verificar y corregir automáticamente problemas de estilo de código:
+
 ```sh
 npm run lint
+# o
+yarn lint
 ```
+
+## Bitácora de Tiempo
+
+Para un análisis del tiempo invertido basado en el historial de commits del repositorio, por favor consulta el archivo [BITACORA.md](BITACORA.md).


### PR DESCRIPTION
Se ha actualizado el archivo README.md para incluir un enlace visible a la aplicación Reditop desplegada en https://reditop.online/.

Esto permite a los usuarios y evaluadores acceder y probar fácilmente la aplicación en vivo.